### PR TITLE
fix typo and russianx string in en locale

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,7 +35,7 @@ en:
       required: "required for this plugin"
     second_authentications:
       init:
-        instruction: Plase choose type of two-factor authentication
+        instruction: Please choose type of two-factor authentication
         disable: "Do not use"
       next_button_html: Next &#187;
       google_auth:
@@ -70,7 +70,7 @@ en:
     auth_code: 'Authorization code'
     resend:
       link: 'Resend code'
-      instruction_html: 'Code sent. Code resending  possible after 5 seconds <span id="otpCodeResendTimer">%{timeout}</span> секунд.'
+      instruction_html: 'Code sent. Code resending possible after <span id="otpCodeResendTimer">%{timeout}</span> seconds.'
     notice:
       auth_code:
         invalid: 'Wrong authorization code'


### PR DESCRIPTION
- typo fixed
- there was a russian word left in a string which also has the time duration in it instead of only the macro as it seems to be in russian locale

